### PR TITLE
Snapshot/Restore API: Add Google Cloud Storage support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ governing permissions and limitations under the License. -->
     <properties>
         <elasticsearch.version>2.0.0-SNAPSHOT</elasticsearch.version>
         <google.gce.version>v1-rev15-1.18.0-rc</google.gce.version>
-        <google.api.version>1.18.0-rc</google.api.version>
+        <google.api.version>1.19.0</google.api.version>
         <lucene.version>5.0.0</lucene.version>
         <lucene.maven.version>5.0.0-snapshot-1637347</lucene.maven.version>
         <tests.shuffle>true</tests.shuffle>

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,15 @@ governing permissions and limitations under the License. -->
 
     <properties>
         <elasticsearch.version>2.0.0-SNAPSHOT</elasticsearch.version>
-        <google.gce.version>v1-rev15-1.18.0-rc</google.gce.version>
+
         <google.api.version>1.19.0</google.api.version>
+        <google.gce.version>v1-rev40-1.19.0</google.gce.version>
+        <google.gcs.version>v1-rev17-1.19.0</google.gcs.version>
+
         <lucene.version>5.0.0</lucene.version>
         <lucene.maven.version>5.0.0-snapshot-1637347</lucene.maven.version>
+        <randomizedtesting.version>2.1.10</randomizedtesting.version>
+
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
         <tests.client.ratio></tests.client.ratio>
@@ -119,7 +124,12 @@ governing permissions and limitations under the License. -->
         <dependency>
           <groupId>com.google.apis</groupId>
           <artifactId>google-api-services-compute</artifactId>
-          <version>${google.gce.version}</version>
+            <version>${google.gce.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-storage</artifactId>
+            <version>${google.gcs.version}</version>
         </dependency>
 
         <!-- Tests -->
@@ -141,7 +151,7 @@ governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.1.10</version>
+            <version>${randomizedtesting.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -185,8 +195,8 @@ governing permissions and limitations under the License. -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -32,6 +32,7 @@ governing permissions and limitations under the License. -->
             <includes>
                 <include>com.google.api-client:google-api-client</include>
                 <include>com.google.apis:google-api-services-compute</include>
+                <include>com.google.apis:google-api-services-storage</include>
                 <include>com.google.oauth-client:google-oauth-client-jetty</include>
                 <include>com.google.http-client:google-http-client-jackson2</include>
             </includes>

--- a/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
@@ -19,25 +19,114 @@
 
 package org.elasticsearch.cloud.gce;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.gce.GceDiscovery;
+
+import static org.elasticsearch.cloud.gce.GoogleCloudStorageService.Fields.CREDENTIALS_FILE;
+import static org.elasticsearch.cloud.gce.GoogleCloudStorageService.Fields.REPOSITORIES_GS;
 
 /**
  *
  */
 public class GceModule extends AbstractModule {
+
+    protected final ESLogger logger;
+
     private Settings settings;
 
     @Inject
     public GceModule(Settings settings) {
+        this.logger = Loggers.getLogger(getClass(), settings);
         this.settings = settings;
     }
 
     @Override
     protected void configure() {
-        bind(GceComputeService.class)
-                .to(settings.getAsClass("cloud.gce.api.impl", GceComputeServiceImpl.class))
-                .asEagerSingleton();
+        // If we have set discovery to "gce", let's start the GCE compute service
+        if (isDiscoveryReady(settings, logger)) {
+            logger.debug("starting Google Compute Engine discovery service");
+            bind(GceComputeService.class)
+                    .to(settings.getAsClass("cloud.gce.api.impl", GceComputeServiceImpl.class))
+                    .asEagerSingleton();
+        }
+
+        // If we have settings for google storage service, let's start theservice
+        if (isSnapshotReady(settings, logger)) {
+            logger.debug("starting Google Cloud Storage repository service");
+            bind(GoogleCloudStorageService.class)
+                    .to(getGoogleCloudStorageServiceClass(settings))
+                    .asEagerSingleton();
+        }
+    }
+
+    public static Class<? extends GoogleCloudStorageService> getGoogleCloudStorageServiceClass(Settings settings) {
+        return settings.getAsClass("cloud.gce.storage.api.impl", GoogleCloudStorageServiceImpl.class);
+    }
+
+    /**
+     * Check if discovery is meant to start
+     *
+     * @return true if we can start discovery features
+     */
+    public static boolean isCloudReady(Settings settings) {
+        return (settings.getAsBoolean("cloud.enabled", true));
+    }
+
+    /**
+     * Check if discovery is meant to start
+     *
+     * @return true if we can start discovery features
+     */
+    public static boolean isDiscoveryReady(Settings settings, ESLogger logger) {
+        // Cloud services are disabled
+        if (!isCloudReady(settings)) {
+            logger.debug("cloud settings are disabled");
+            return false;
+        }
+
+        // User set discovery.type: gce
+        if (!GceDiscovery.GCE.equalsIgnoreCase(settings.get("discovery.type"))) {
+            logger.debug("discovery.type not set to {}", GceDiscovery.GCE);
+            return false;
+        }
+        logger.debug("all required properties for Google Compute Engine discovery are set!");
+
+        return true;
+    }
+
+    /**
+     * Check if we have repository settings available
+     *
+     * @return true if we can use snapshot and restore
+     */
+    public static boolean isSnapshotReady(Settings settings, ESLogger logger) {
+        // Cloud services are disabled
+        if (!isCloudReady(settings)) {
+            logger.debug("cloud settings are disabled");
+            return false;
+        }
+
+        if (isPropertyMissing(settings, REPOSITORIES_GS + CREDENTIALS_FILE, logger)) {
+            logger.debug("{} not set", REPOSITORIES_GS + CREDENTIALS_FILE);
+            return false;
+        }
+        logger.debug("all required properties for Google Storage repository are set");
+        return true;
+    }
+
+    private static boolean isPropertyMissing(Settings settings, String name, ESLogger logger) throws ElasticsearchException {
+        if (!Strings.hasText(settings.get(name))) {
+            if (logger != null) {
+                logger.warn("{} is not set or is incorrect.", name);
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce;
+
+import com.google.api.services.storage.Storage;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.component.LifecycleComponent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+
+public interface GoogleCloudStorageService extends LifecycleComponent<GoogleCloudStorageService> {
+
+    static public final class Fields {
+        public static final String REPOSITORIES_GS = "repositories.gcs.";
+        public static final String PROJECT_ID = "project_id";
+        public static final String BUCKET = "bucket";
+        public static final String BUCKET_LOCATION = "location";
+        public static final String CHUNK_SIZE = "chunk_size";
+        public static final String COMPRESS = "compress";
+        public static final String BASE_PATH = "base_path";
+        public static final String CREDENTIALS_FILE = "credentials_file";
+        public static final String APPLICATION_NAME = "application_name";
+        public static final String PROXY_HOST = "proxy_host";
+        public static final String PROXY_PORT = "proxy_port";
+    }
+
+    /**
+     * Return true if the given bucket exists
+     *
+     * @param bucketName
+     * @return
+     */
+    boolean doesBucketExist(String bucketName) throws IOException;
+
+    /**
+     * Creates a new bucket.
+     *
+     * @param projectName
+     * @param bucketName
+     * @param location
+     * @throws IOException
+     */
+    void createBucket(String projectName, String bucketName, String location) throws IOException;
+
+    /**
+     * Deletes all blobs in a given bucket
+     *
+     * @param bucketName
+     * @param path
+     */
+    void deleteBlobs(String bucketName, String path) throws IOException;
+
+    /**
+     * Returns true if the blob exists
+     *
+     * @param bucketName
+     * @param blobName
+     * @return
+     */
+    boolean blobExists(String bucketName, String blobName) throws IOException;
+
+    /**
+     * Deletes a blob in a given bucket
+     *
+     * @param bucketName
+     * @param blobName
+     * @throws IOException
+     */
+    void deleteBlob(String bucketName, String blobName) throws IOException;
+
+    /**
+     * Returns an {@link java.io.InputStream} for a given blob
+     *
+     * @param bucketName
+     * @param blobName
+     * @return
+     */
+    InputStream getInputStream(String bucketName, String blobName) throws IOException;
+
+    /**
+     * Returns an {@link java.io.OutputStream} that can be used to write blobs.
+     *
+     * @param bucketName
+     * @param blobName
+     * @return
+     */
+    OutputStream getOutputStream(String bucketName, String blobName) throws IOException;
+
+    /**
+     * List all blobs in a given bucket which have a prefix
+     *
+     * @param bucketName
+     * @param path
+     * @param prefix
+     * @return
+     */
+    ImmutableMap<String,BlobMetaData> listBlobsByPrefix(String bucketName, String path, String prefix) throws IOException;
+
+    /**
+     * Prepare an insert/upload request.
+     *
+     * @param bucketName
+     * @param blobName
+     * @param input
+     * @return
+     * @throws IOException
+     */
+    Storage.Objects.Insert prepareInsert(String bucketName, String blobName, InputStream input) throws IOException;
+
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.component.LifecycleComponent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.GeneralSecurityException;
+import java.util.concurrent.Executor;
 
 public interface GoogleCloudStorageService extends LifecycleComponent<GoogleCloudStorageService> {
 
@@ -101,11 +101,12 @@ public interface GoogleCloudStorageService extends LifecycleComponent<GoogleClou
     /**
      * Returns an {@link java.io.OutputStream} that can be used to write blobs.
      *
+     * @param  executor
      * @param bucketName
      * @param blobName
      * @return
      */
-    OutputStream getOutputStream(String bucketName, String blobName) throws IOException;
+    OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException;
 
     /**
      * List all blobs in a given bucket which have a prefix

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageService.java
@@ -37,6 +37,7 @@ public interface GoogleCloudStorageService extends LifecycleComponent<GoogleClou
         public static final String BUCKET = "bucket";
         public static final String BUCKET_LOCATION = "location";
         public static final String CHUNK_SIZE = "chunk_size";
+        public static final String BUFFER_SIZE = "buffer_size";
         public static final String COMPRESS = "compress";
         public static final String BASE_PATH = "base_path";
         public static final String CREDENTIALS_FILE = "credentials_file";
@@ -104,9 +105,10 @@ public interface GoogleCloudStorageService extends LifecycleComponent<GoogleClou
      * @param  executor
      * @param bucketName
      * @param blobName
+     * @param bufferSizeInBytes
      * @return
      */
-    OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException;
+    OutputStream getOutputStream(Executor executor, String bucketName, String blobName, int bufferSizeInBytes) throws IOException;
 
     /**
      * List all blobs in a given bucket which have a prefix

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
@@ -176,11 +176,11 @@ public class GoogleCloudStorageServiceImpl extends AbstractLifecycleComponent<Go
     }
 
     @Override
-    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException {
+    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName, int bufferSizeInBytes) throws IOException {
         // The concurrent upload does buffering internally
         ConcurrentUpload upload = prepareConcurrentUpload(bucketName, blobName);
         // ConcurrentUpload is executed in a dedicated thread
-        return new GoogleCloudStorageOutputStream(executor, upload);
+        return new GoogleCloudStorageOutputStream(executor, upload, bufferSizeInBytes);
     }
 
     protected <T> T prepareConcurrentUpload(String bucketName, String blobName) {

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce;
+
+import com.google.api.client.googleapis.GoogleUtils;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.Objects;
+import com.google.api.services.storage.model.StorageObject;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.cloud.gce.blobstore.ConcurrentUpload;
+import org.elasticsearch.cloud.gce.blobstore.GoogleCloudStorageConcurrentUpload;
+import org.elasticsearch.cloud.gce.blobstore.GoogleCloudStorageOutputStream;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+
+/**
+ * See https://code.google.com/p/google-api-java-client/source/browse/storage-cmdline-sample/src/main/java/com/google/api/services/samples/storage/cmdline/StorageSample.java?repo=samples#477
+ * See https://github.com/pliablematter/simple-cloud-storage/blob/master/src/main/java/com/pliablematter/cloudstorage/CloudStorage.java
+ */
+public class GoogleCloudStorageServiceImpl extends AbstractLifecycleComponent<GoogleCloudStorageService> implements GoogleCloudStorageService {
+
+    private GoogleCredential credentials;
+
+    private Storage client;
+
+    private ThreadPool threadPool;
+
+    @Inject
+    public GoogleCloudStorageServiceImpl(Settings settings, ThreadPool threadPool) throws IOException, GeneralSecurityException {
+        super(settings);
+        this.threadPool = threadPool;
+
+        this.credentials = loadCredentials();
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("using service account id [{}] with key [{}]", credentials.getServiceAccountId(), credentials.getServiceAccountPrivateKey());
+        }
+
+        // Now we can set up other large objects
+
+        // Sets up the HTTP transport
+        NetHttpTransport.Builder httpTransport = new NetHttpTransport.Builder();
+        httpTransport.trustCertificates(GoogleUtils.getCertificateTrustStore());
+
+        String proxyHost = settings.get(Fields.REPOSITORIES_GS + Fields.PROXY_HOST);
+        if (proxyHost != null) {
+            String portString = settings.get(Fields.REPOSITORIES_GS + Fields.PROXY_PORT, "80");
+            Integer proxyPort;
+            try {
+                proxyPort = Integer.parseInt(portString, 10);
+            } catch (NumberFormatException ex) {
+                throw new ElasticsearchIllegalArgumentException("The configured proxy port value [" + portString + "] is invalid", ex);
+            }
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            httpTransport.setProxy(proxy);
+        }
+
+        String applicationName = settings.get(Fields.REPOSITORIES_GS + Fields.APPLICATION_NAME, "elasticsearch-google-cloud-storage-service");
+
+        // Instanciates the Google Cloud Storage client
+        Storage.Builder storage = new Storage.Builder(httpTransport.build(), JacksonFactory.getDefaultInstance(), credentials);
+        storage.setApplicationName(applicationName);
+
+        client = storage.build();
+        logger.debug("Google Cloud Storage client initialized");
+    }
+
+    private GoogleCredential loadCredentials() throws IOException {
+        String credentialsFilePath = settings.get(Fields.REPOSITORIES_GS + Fields.CREDENTIALS_FILE);
+        if (credentialsFilePath == null) {
+            throw new ElasticsearchIllegalArgumentException("The configured " + Fields.CREDENTIALS_FILE + " value [" + credentialsFilePath + "] is invalid");
+        }
+        logger.debug("Google Cloud Storage credentials file set to [{}]", credentialsFilePath);
+
+        try (InputStream is = new FileInputStream(new File(credentialsFilePath))) {
+            logger.debug("loading credentials from [{}]", credentialsFilePath);
+            return GoogleCredential.fromStream(is)
+                    .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_FULL_CONTROL));
+        } catch (IOException e) {
+            logger.error("Cannot load Google Cloud Storage credentials from file [{}]", credentialsFilePath, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean doesBucketExist(String bucketName) throws IOException {
+        try {
+            if (logger.isDebugEnabled()) {
+                logger.debug("checking if bucket [{}] exists", bucketName);
+            }
+            Bucket bucket = client.buckets().get(bucketName).execute();
+            if (bucket != null) {
+                return Strings.hasText(bucket.getId());
+            }
+        } catch (GoogleJsonResponseException e) {
+            if ((e.getStatusCode() == HTTP_FORBIDDEN) || (e.getStatusCode() == HTTP_NOT_FOUND)) {
+                return false;
+            }
+            throw e;
+        }
+        return false;
+    }
+
+    @Override
+    public void createBucket(String projectName, String bucketName, String location) throws IOException {
+        Bucket bucket = new Bucket();
+        bucket.setName(bucketName);
+        if (location != null) {
+            bucket.setLocation(location);
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("creating bucket [{}] for project [{}]", bucketName, projectName);
+        }
+        client.buckets().insert(projectName, bucket).execute();
+    }
+
+    @Override
+    public boolean blobExists(String bucketName, String blobName) throws IOException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("checking if blob [{}] exists in bucket [{}]", blobName, bucketName);
+        }
+        StorageObject blob = client.objects().get(bucketName, blobName).execute();
+        return blob != null;
+    }
+
+    @Override
+    public void deleteBlob(String bucketName, String blobName) throws IOException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("deleting blob [{}] in bucket [{}]", blobName, bucketName);
+        }
+        client.objects().delete(bucketName, blobName).execute();
+    }
+
+    @Override
+    public InputStream getInputStream(String bucketName, String blobName) throws IOException {
+        Storage.Objects.Get object = client.objects().get(bucketName, blobName);
+        return object.executeMediaAsInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream(String bucketName, String blobName) throws IOException {
+        // The concurrent upload does buffering internally
+        ConcurrentUpload upload = prepareConcurrentUpload(bucketName, blobName);
+        // NOTE: Generic thread pool is used.
+        return new GoogleCloudStorageOutputStream(threadPool.generic(), upload);
+    }
+
+    protected <T> T prepareConcurrentUpload(String bucketName, String blobName) {
+        return (T) new GoogleCloudStorageConcurrentUpload(this, bucketName, blobName);
+    }
+
+    @Override
+    public Storage.Objects.Insert prepareInsert(String bucketName, String blobName, InputStream input) throws IOException {
+        InputStreamContent streamContent =  new InputStreamContent("application/octet-stream", input);
+        Storage.Objects.Insert insert = client.objects().insert(bucketName, null, streamContent);
+        insert.setName(blobName);
+        return insert;
+    }
+
+    @Override
+    protected void doStart() throws ElasticsearchException {
+
+    }
+
+    @Override
+    protected void doStop() throws ElasticsearchException {
+
+    }
+
+    @Override
+    protected void doClose() throws ElasticsearchException {
+
+    }
+
+    @Override
+    public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(final String bucketName, final String path, final String prefix) throws IOException {
+        final ImmutableMap.Builder<String, BlobMetaData> blobsBuilder = ImmutableMap.builder();
+        forEachStorageObject(bucketName, path, prefix, new StorageObjectCallback() {
+            @Override
+            void doWithStorageObject(StorageObject object) {
+                String name = object.getName().substring(path.length());
+                blobsBuilder.put(name, new PlainBlobMetaData(name, object.getSize().longValue()));
+            }
+        });
+        return blobsBuilder.build();
+    }
+
+    @Override
+    public void deleteBlobs(String bucketName, String path) throws IOException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("delete all blobs of bucket [{}] and path [{}]",
+                    bucketName, path);
+        }
+
+        forEachStorageObject(bucketName, path, null, new StorageObjectCallback() {
+            @Override
+            void doWithStorageObject(StorageObject object) throws IOException {
+                client.objects().delete(object.getBucket(), object.getName()).execute();
+            }
+        });
+    }
+
+    private void forEachStorageObject(String bucketName, String path, String prefix, StorageObjectCallback callback) throws IOException {
+        if (callback == null) {
+            return;
+        }
+        Storage.Objects.List list = client.objects().list(bucketName);
+        if (prefix != null) {
+            list.setPrefix(path + prefix);
+        } else {
+            list.setPrefix(path);
+        }
+        list.setMaxResults(100L);
+        Objects objects = list.execute();
+
+        while ((objects.getItems() != null) && (!objects.getItems().isEmpty())) {
+
+            for (StorageObject object : objects.getItems()) {
+                callback.doWithStorageObject(object);
+            }
+
+            String nextPageToken = objects.getNextPageToken();
+            if (nextPageToken == null) {
+                break;
+            }
+            list.setPageToken(nextPageToken);
+
+            // Fetch next page of objects
+            objects = list.execute();
+        }
+    }
+
+    private abstract class StorageObjectCallback {
+        abstract void doWithStorageObject(StorageObject object) throws IOException;
+    }
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/GoogleCloudStorageServiceImpl.java
@@ -42,13 +42,13 @@ import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.concurrent.Executor;
 
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -63,12 +63,9 @@ public class GoogleCloudStorageServiceImpl extends AbstractLifecycleComponent<Go
 
     private Storage client;
 
-    private ThreadPool threadPool;
-
     @Inject
-    public GoogleCloudStorageServiceImpl(Settings settings, ThreadPool threadPool) throws IOException, GeneralSecurityException {
+    public GoogleCloudStorageServiceImpl(Settings settings) throws IOException, GeneralSecurityException {
         super(settings);
-        this.threadPool = threadPool;
 
         this.credentials = loadCredentials();
 
@@ -179,11 +176,11 @@ public class GoogleCloudStorageServiceImpl extends AbstractLifecycleComponent<Go
     }
 
     @Override
-    public OutputStream getOutputStream(String bucketName, String blobName) throws IOException {
+    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException {
         // The concurrent upload does buffering internally
         ConcurrentUpload upload = prepareConcurrentUpload(bucketName, blobName);
-        // NOTE: Generic thread pool is used.
-        return new GoogleCloudStorageOutputStream(threadPool.generic(), upload);
+        // ConcurrentUpload is executed in a dedicated thread
+        return new GoogleCloudStorageOutputStream(executor, upload);
     }
 
     protected <T> T prepareConcurrentUpload(String bucketName, String blobName) {

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/ConcurrentUpload.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/ConcurrentUpload.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface ConcurrentUpload<T> extends Runnable {
+
+    /**
+     * Initialize the upload request.
+     * The implementation must close the stream when the upload is finished.
+     */
+    void initializeUpload(InputStream inputStream) throws IOException;
+
+    /**
+     * Waits & blocks until the upload is terminated, whatever the final status (success/error)
+     */
+    void waitForCompletion();
+
+    /**
+     * @return true if the upload is completed
+     */
+    boolean isCompleted();
+
+    /**
+     * @return the uploaded object, if the upload succeed
+     */
+    T getUploadedObject();
+
+    /**
+     * @return an exception, if the upload failed
+     */
+    Exception getException();
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
@@ -90,9 +90,8 @@ public class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public boolean deleteBlob(String blobName) throws IOException {
+    public void deleteBlob(String blobName) throws IOException {
         blobStore.client().deleteBlob(blobStore.bucket(), buildKey(blobName));
-        return true;
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStoreException;
+import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+
+public class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
+
+    protected final ESLogger logger = ESLoggerFactory.getLogger(GoogleCloudStorageBlobContainer.class.getName());
+
+    protected final GoogleCloudStorageBlobStore blobStore;
+
+    protected final String keyPath;
+
+    public GoogleCloudStorageBlobContainer(BlobPath path, GoogleCloudStorageBlobStore blobStore) {
+        super(path);
+        this.blobStore = blobStore;
+
+        String keyPath = path.buildAsString("/");
+        if (!keyPath.isEmpty()) {
+            keyPath = keyPath + "/";
+        }
+        this.keyPath = keyPath;
+    }
+
+    @Override
+    public boolean blobExists(String blobName) {
+        try {
+            return blobStore.client().blobExists(blobStore.bucket(), buildKey(blobName));
+        } catch (GoogleJsonResponseException e) {
+            GoogleJsonError error = e.getDetails();
+            if ((e.getStatusCode() == HTTP_NOT_FOUND) || ((error != null) && (error.getCode() == HTTP_NOT_FOUND))) {
+                return false;
+            }
+        } catch (IOException e) {
+            throw new BlobStoreException("failed to check if blob exists", e);
+        }
+        return false;
+    }
+
+    @Override
+    public InputStream openInput(String blobName) throws IOException {
+        try {
+            return blobStore.client().getInputStream(blobStore.bucket(), buildKey(blobName));
+        } catch (GoogleJsonResponseException e) {
+            GoogleJsonError error = e.getDetails();
+            if ((e.getStatusCode() == HTTP_NOT_FOUND) || ((error != null) && (error.getCode() == HTTP_NOT_FOUND))) {
+                throw new FileNotFoundException(e.getMessage());
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public OutputStream createOutput(String blobName) throws IOException {
+        return blobStore.client().getOutputStream(blobStore.bucket(), buildKey(blobName));
+    }
+
+    @Override
+    public boolean deleteBlob(String blobName) throws IOException {
+        blobStore.client().deleteBlob(blobStore.bucket(), buildKey(blobName));
+        return true;
+    }
+
+    @Override
+    public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(@Nullable String prefix) throws IOException {
+        return blobStore.client().listBlobsByPrefix(blobStore.bucket(), keyPath, prefix);
+    }
+
+    @Override
+    public ImmutableMap<String, BlobMetaData> listBlobs() throws IOException {
+        return listBlobsByPrefix(null);
+    }
+
+    protected String buildKey(String blobName) {
+        return keyPath + blobName;
+    }
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
@@ -86,7 +86,7 @@ public class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
 
     @Override
     public OutputStream createOutput(String blobName) throws IOException {
-        return blobStore.client().getOutputStream(blobStore.bucket(), buildKey(blobName));
+        return blobStore.client().getOutputStream(blobStore.executor(), blobStore.bucket(), buildKey(blobName));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobContainer.java
@@ -86,7 +86,7 @@ public class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
 
     @Override
     public OutputStream createOutput(String blobName) throws IOException {
-        return blobStore.client().getOutputStream(blobStore.executor(), blobStore.bucket(), buildKey(blobName));
+        return blobStore.client().getOutputStream(blobStore.executor(), blobStore.bucket(), buildKey(blobName), blobStore.bufferSizeInBytes());
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -45,11 +46,15 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
 
     private final String bucket;
 
-    public GoogleCloudStorageBlobStore(Settings settings, Executor executor, GoogleCloudStorageService client, String projectName, String bucketName, String bucketLocation) throws IOException {
+    private final ByteSizeValue bufferSize;
+
+    public GoogleCloudStorageBlobStore(Settings settings, Executor executor, GoogleCloudStorageService client, String projectName,
+                                       String bucketName, String bucketLocation, ByteSizeValue bufferSize) throws IOException {
         super(settings);
         this.executor = executor;
         this.client = client;
         this.bucket = bucketName;
+        this.bufferSize =  bufferSize;
 
         try {
             if (!client.doesBucketExist(bucketName)) {
@@ -81,6 +86,10 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
 
     public String bucket() {
         return bucket;
+    }
+
+    public int bufferSizeInBytes() {
+        return bufferSize.bytesAsInt();
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.util.concurrent.Executor;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 
@@ -38,12 +39,15 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
  */
 public class GoogleCloudStorageBlobStore extends AbstractComponent implements BlobStore {
 
+    private final Executor executor;
+
     private final GoogleCloudStorageService client;
 
     private final String bucket;
 
-    public GoogleCloudStorageBlobStore(Settings settings, GoogleCloudStorageService client, String projectName, String bucketName, String bucketLocation) throws IOException {
+    public GoogleCloudStorageBlobStore(Settings settings, Executor executor, GoogleCloudStorageService client, String projectName, String bucketName, String bucketLocation) throws IOException {
         super(settings);
+        this.executor = executor;
         this.client = client;
         this.bucket = bucketName;
 
@@ -67,6 +71,10 @@ public class GoogleCloudStorageBlobStore extends AbstractComponent implements Bl
         }
     }
 
+    public Executor executor() {
+        return executor;
+    }
+    
     public GoogleCloudStorageService client() {
         return client;
     }

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageBlobStore.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+
+/**
+ * BlobStore implementation that uses Google Cloud Storage service as a backend.
+ */
+public class GoogleCloudStorageBlobStore extends AbstractComponent implements BlobStore {
+
+    private final GoogleCloudStorageService client;
+
+    private final String bucket;
+
+    public GoogleCloudStorageBlobStore(Settings settings, GoogleCloudStorageService client, String projectName, String bucketName, String bucketLocation) throws IOException {
+        super(settings);
+        this.client = client;
+        this.bucket = bucketName;
+
+        try {
+            if (!client.doesBucketExist(bucketName)) {
+                client.createBucket(projectName, bucketName, bucketLocation);
+            }
+        } catch (GoogleJsonResponseException e) {
+            logger.error("exception occurs when checking for bucket existence", e);
+            GoogleJsonError error = e.getDetails();
+            if ((error != null) && (error.getCode() == HTTP_CONFLICT)) {
+                String message = error.getMessage();
+                if (message != null) {
+                    if (message.contains("You already own this bucket.")
+                            || message.contains("Sorry, that name is not available. Please try a different one.")) {
+                        throw new FileAlreadyExistsException("Bucket [" + bucketName + "] cannot be created: " + message);
+                    }
+                }
+            }
+            throw e;
+        }
+    }
+
+    public GoogleCloudStorageService client() {
+        return client;
+    }
+
+    public String bucket() {
+        return bucket;
+    }
+
+    @Override
+    public BlobContainer blobContainer(BlobPath path) {
+        return new GoogleCloudStorageBlobContainer(path, this);
+    }
+
+    @Override
+    public void delete(BlobPath path) {
+        String keyPath = path.buildAsString("/");
+        if (!keyPath.isEmpty()) {
+            keyPath = keyPath + "/";
+        }
+
+        try {
+            client.deleteBlobs(bucket, keyPath);
+        } catch (IOException e) {
+            logger.warn("can not remove [{}] in bucket [{}]: {}", keyPath, bucket, e.getMessage());
+        }
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
@@ -81,16 +81,11 @@ public class GoogleCloudStorageConcurrentUpload implements ConcurrentUpload<Stor
 
     @Override
     public void waitForCompletion() {
-        while ((done.getCount() > 0) && (exception == null)) {
-            try {
-                boolean completed = done.await(50, TimeUnit.MILLISECONDS);
-                if (completed) {
-                    return;
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                exception = e;
-            }
+        try {
+            done.await(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            exception = e;
         }
     }
 

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import com.google.api.client.googleapis.media.MediaHttpUploader;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of ConcurrentUpload for Google Cloud Storage. This class executes a
+ * Storage.Objects.Insert request that reads an InputStream (wrapped in an InputStreamContent)
+ * and uploads it in multiple chunk_size
+ */
+public class GoogleCloudStorageConcurrentUpload implements ConcurrentUpload<StorageObject> {
+
+    /**
+     * Only 1 concurrent request is allowed by the GCS API
+     */
+    private final CountDownLatch done = new CountDownLatch(1);
+
+    private GoogleCloudStorageService client;
+
+    private String bucketName;
+    private String blobName;
+
+    private InputStream input;
+
+    private Storage.Objects.Insert request;
+    private StorageObject response;
+
+    private Exception exception;
+
+    public GoogleCloudStorageConcurrentUpload(GoogleCloudStorageService client, String bucketName, String blobName) {
+        this.client = client;
+        this.bucketName = bucketName;
+        this.blobName = blobName;
+    }
+
+    @Override
+    public void initializeUpload(InputStream inputStream) throws IOException {
+        this.input = inputStream;
+        request = client.prepareInsert(bucketName, blobName, inputStream);
+    }
+
+    @Override
+    public void run() {
+        try {
+            response = request.execute();
+        } catch (Exception e) {
+            exception = e;
+
+        } finally {
+            done.countDown();
+            IOUtils.closeWhileHandlingException(input);
+        }
+    }
+
+    @Override
+    public void waitForCompletion() {
+        while ((done.getCount() > 0) && (exception == null)) {
+            try {
+                boolean completed = done.await(50, TimeUnit.MILLISECONDS);
+                if (completed) {
+                    return;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exception = e;
+            }
+        }
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return  (request.getMediaHttpUploader() != null)
+                && (request.getMediaHttpUploader().getUploadState() != null)
+                && (request.getMediaHttpUploader().getUploadState().equals(MediaHttpUploader.UploadState.MEDIA_COMPLETE));
+    }
+
+    @Override
+    public StorageObject getUploadedObject() {
+        return response;
+    }
+
+    @Override
+    public Exception getException() {
+        return exception;
+    }
+
+
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageConcurrentUpload.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cloud.gce.blobstore;
 import com.google.api.client.googleapis.media.MediaHttpUploader;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
 
 import java.io.IOException;
@@ -75,7 +74,13 @@ public class GoogleCloudStorageConcurrentUpload implements ConcurrentUpload<Stor
 
         } finally {
             done.countDown();
-            IOUtils.closeWhileHandlingException(input);
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    // Ignore
+                }
+            }
         }
     }
 

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStream.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStream.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.Preconditions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.concurrent.Executor;
+
+
+public class GoogleCloudStorageOutputStream extends OutputStream {
+
+    /**
+     * The PipedOutputStream is used by the caller to write data that are directly
+     * piped to the PipedInputStream.
+     */
+    private PipedOutputStream output = new PipedOutputStream();
+
+    /**
+     * The PipedInputStream is used by a ConcurrentUpload object to read the data to send
+     * to Google Cloud Storage.
+     */
+    private PipedInputStream input;
+
+    /**
+     * A ConcurrentUpload represents an upload request that is executed in the background.
+     * This object reads the data to send from a PipedInputStream.
+     */
+    private ConcurrentUpload upload;
+
+    /**
+     * Executor used to executes the concurrent upload
+     */
+    private Executor executor;
+
+    public GoogleCloudStorageOutputStream(Executor executor, ConcurrentUpload upload) {
+        Preconditions.checkNotNull(executor, "An executor must be provided");
+        this.executor = executor;
+        Preconditions.checkNotNull(upload, "An upload request must be provided");
+        this.upload = upload;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (input == null) {
+            // Connects output -> input
+            input = new PipedInputStream(output);
+
+            // Connects input -> concurrent upload
+            upload.initializeUpload(input);
+
+            // Starts the concurrent upload
+            executor.execute(upload);
+        }
+
+        // Rethrow exception if something wrong happen
+        checkForConcurrentUploadErrors();
+
+        output.write(b);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.closeWhileHandlingException(output);
+
+        if (input != null) {
+            try {
+                // Waits for the upload request to complete
+                upload.waitForCompletion();
+
+                // Rethrow exception if something wrong happen
+                checkForConcurrentUploadErrors();
+
+            } finally {
+                IOUtils.closeWhileHandlingException(output);
+                output = null;
+                input = null;
+                upload = null;
+            }
+        }
+    }
+
+    /**
+     * Check the status of the ConcurrentUpload and throws an exception if something wrong happen
+     *
+     * @throws IOException
+     */
+    protected void checkForConcurrentUploadErrors() throws IOException {
+        if ((upload != null) && (upload.getException() != null)) {
+            throw new IOException("Detected exception while uploading blob", upload.getException());
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStream.java
+++ b/src/main/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStream.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cloud.gce.blobstore;
 
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.Preconditions;
 
 import java.io.IOException;
@@ -82,7 +81,13 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        IOUtils.closeWhileHandlingException(output);
+        if (output != null) {
+            try {
+                output.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
 
         if (input != null) {
             try {
@@ -93,7 +98,6 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
                 checkForConcurrentUploadErrors();
 
             } finally {
-                IOUtils.closeWhileHandlingException(output);
                 output = null;
                 input = null;
                 upload = null;

--- a/src/main/java/org/elasticsearch/discovery/gce/GceDiscovery.java
+++ b/src/main/java/org/elasticsearch/discovery/gce/GceDiscovery.java
@@ -43,6 +43,8 @@ import org.elasticsearch.transport.TransportService;
  */
 public class GceDiscovery extends ZenDiscovery {
 
+    public static final String GCE = "gce";
+
     @Inject
     public GceDiscovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,
                         ClusterService clusterService, NodeSettingsService nodeSettingsService, ZenPingService pingService,

--- a/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
@@ -23,8 +23,6 @@ import org.elasticsearch.cloud.gce.GceModule;
 import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.AbstractPlugin;
 import org.elasticsearch.repositories.RepositoriesModule;

--- a/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepository.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+import org.elasticsearch.cloud.gce.blobstore.GoogleCloudStorageBlobStore;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.snapshots.IndexShardRepository;
+import org.elasticsearch.repositories.RepositoryException;
+import org.elasticsearch.repositories.RepositoryName;
+import org.elasticsearch.repositories.RepositorySettings;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.elasticsearch.cloud.gce.GoogleCloudStorageService.Fields.*;
+
+
+/**
+ * Repository implementation that uses Google Cloud Storage service as a backend.
+ */
+public class GoogleCloudStorageRepository extends BlobStoreRepository {
+
+    public final static String TYPE = "gcs";
+
+    private final GoogleCloudStorageBlobStore blobStore;
+
+    private final BlobPath basePath;
+
+    private ByteSizeValue chunkSize;
+
+    private boolean compress;
+
+    @Inject
+    public GoogleCloudStorageRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository, GoogleCloudStorageService googleCloudStorageService) throws IOException {
+        super(name.name(), repositorySettings, indexShardRepository);
+
+        String projectId = repositorySettings.settings().get(PROJECT_ID, componentSettings.get(PROJECT_ID, settings.get(REPOSITORIES_GS + PROJECT_ID, settings.get("cloud.gce." + PROJECT_ID))));
+        if (!Strings.hasText(projectId)) {
+            throw new RepositoryException(name.name(), "No project id defined for Google Cloud Storage repository");
+        }
+
+        String bucketName = repositorySettings.settings().get(BUCKET, componentSettings.get(BUCKET, settings.get(REPOSITORIES_GS + BUCKET)));
+        if (!Strings.hasText(bucketName)) {
+            throw new RepositoryException(name.name(), "No bucket defined for Google Cloud Storage repository");
+        }
+
+        String bucketLocation = repositorySettings.settings().get(BUCKET_LOCATION, componentSettings.get(BUCKET_LOCATION));
+        if (bucketLocation == null) {
+            // Checks for a default location
+            String defaultLocation = repositorySettings.settings().get(REPOSITORIES_GS + BUCKET_LOCATION, settings.get(REPOSITORIES_GS + BUCKET_LOCATION));
+            if (defaultLocation != null) {
+                defaultLocation = defaultLocation.toUpperCase(Locale.ENGLISH);
+                if ("US".equals(defaultLocation)) {
+                    // Default location - setting location to null
+                    bucketLocation = null;
+                } else if ("EU".equals(defaultLocation)) {
+                    bucketLocation = "EU";
+                } else if ("ASIA".equals(defaultLocation)) {
+                    bucketLocation = "ASIA";
+                }
+            }
+        }
+
+        this.chunkSize = repositorySettings.settings().getAsBytesSize(CHUNK_SIZE, componentSettings.getAsBytesSize(CHUNK_SIZE, new ByteSizeValue(100, ByteSizeUnit.MB)));
+        this.compress = repositorySettings.settings().getAsBoolean(COMPRESS, componentSettings.getAsBoolean(COMPRESS, false));
+
+        String basePath = repositorySettings.settings().get(BASE_PATH, null);
+        if (Strings.hasLength(basePath)) {
+            // Remove starting / if any
+            basePath = Strings.trimLeadingCharacter(basePath, '/');
+            BlobPath path = new BlobPath();
+            for (String elem : Strings.splitStringToArray(basePath, '/')) {
+                path = path.add(elem);
+            }
+            this.basePath = path;
+        } else {
+            this.basePath = BlobPath.cleanPath();
+        }
+
+        logger.debug("using  projet id [{}], bucket [{}], location [{}], base_path [{}], chunk_size [{}], compress [{}]",
+                projectId, bucketName, bucketLocation, basePath, chunkSize, compress);
+        this.blobStore = new GoogleCloudStorageBlobStore(settings, googleCloudStorageService, projectId, bucketName, bucketLocation);
+    }
+
+
+    @Override
+    protected BlobStore blobStore() {
+        return blobStore;
+    }
+
+    @Override
+    protected BlobPath basePath() {
+        return basePath;
+    }
+
+    @Override
+    protected boolean isCompress() {
+        return compress;
+    }
+
+    @Override
+    protected ByteSizeValue chunkSize() {
+        return chunkSize;
+    }
+}

--- a/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepository.java
@@ -49,6 +49,8 @@ public class GoogleCloudStorageRepository extends BlobStoreRepository {
 
     public final static String TYPE = "gcs";
 
+    public static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(1, ByteSizeUnit.MB);
+
     private final GoogleCloudStorageBlobStore blobStore;
 
     private final BlobPath basePath;
@@ -105,11 +107,13 @@ public class GoogleCloudStorageRepository extends BlobStoreRepository {
         }
 
         int concurrentStreams = repositorySettings.settings().getAsInt("concurrent_streams", componentSettings.getAsInt("concurrent_streams", 5));
-        ExecutorService concurrentStreamPool = EsExecutors.newScaling(1, concurrentStreams, 5, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory(settings, "[s3_stream]"));
+        ExecutorService concurrentStreamPool = EsExecutors.newScaling(1, concurrentStreams, 5, TimeUnit.SECONDS, EsExecutors.daemonThreadFactory(settings, "[gcs_stream]"));
+
+        ByteSizeValue bufferSize = repositorySettings.settings().getAsBytesSize(BUFFER_SIZE, componentSettings.getAsBytesSize(BUFFER_SIZE, DEFAULT_BUFFER_SIZE));
 
         logger.debug("using  projet id [{}], bucket [{}], location [{}], base_path [{}], chunk_size [{}], compress [{}]",
                 projectId, bucketName, bucketLocation, basePath, chunkSize, compress);
-        this.blobStore = new GoogleCloudStorageBlobStore(settings, concurrentStreamPool, googleCloudStorageService, projectId, bucketName, bucketLocation);
+        this.blobStore = new GoogleCloudStorageBlobStore(settings, concurrentStreamPool, googleCloudStorageService, projectId, bucketName, bucketLocation, bufferSize);
     }
 
 

--- a/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepositoryModule.java
+++ b/src/main/java/org/elasticsearch/repositories/gce/GoogleCloudStorageRepositoryModule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.snapshots.IndexShardRepository;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardRepository;
+import org.elasticsearch.repositories.Repository;
+
+/**
+ * Module for Google Cloud Storage repository
+ */
+public class GoogleCloudStorageRepositoryModule extends AbstractModule {
+
+    public GoogleCloudStorageRepositoryModule() {
+        super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void configure() {
+        bind(Repository.class).to(GoogleCloudStorageRepository.class).asEagerSingleton();
+        bind(IndexShardRepository.class).to(BlobStoreIndexShardRepository.class).asEagerSingleton();
+    }
+}
+

--- a/src/test/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStreamTest.java
+++ b/src/test/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStreamTest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cloud.gce.blobstore;
 import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.repositories.gce.GoogleCloudStorageRepository;
 import org.elasticsearch.repositories.gce.MockGoogleCloudStorageService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.After;
@@ -46,6 +47,8 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class GoogleCloudStorageOutputStreamTest extends ElasticsearchTestCase {
 
+    private int bufferSize = GoogleCloudStorageRepository.DEFAULT_BUFFER_SIZE.bytesAsInt();
+
     private ExecutorService executor;
 
     @Before
@@ -67,7 +70,7 @@ public class GoogleCloudStorageOutputStreamTest extends ElasticsearchTestCase {
     @Test
     public void testWriteRandomDataToMockConcurrentUpload() throws IOException {
         ConcurrentUpload<byte[]> upload = new MockConcurrentUpload();
-        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload);
+        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload, bufferSize);
 
         Integer randomLength = randomIntBetween(1, 10000000);
         ByteArrayOutputStream content = new ByteArrayOutputStream(randomLength);
@@ -90,7 +93,7 @@ public class GoogleCloudStorageOutputStreamTest extends ElasticsearchTestCase {
         GoogleCloudStorageService service = new MockGoogleCloudStorageService(ImmutableSettings.EMPTY, result);
 
         GoogleCloudStorageConcurrentUpload upload = new GoogleCloudStorageConcurrentUpload(service, "test-bucket", "test-project");
-        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload);
+        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload, bufferSize);
 
         Integer randomLength = randomIntBetween(1, 10000000);
         ByteArrayOutputStream content = new ByteArrayOutputStream(randomLength);
@@ -139,7 +142,7 @@ public class GoogleCloudStorageOutputStreamTest extends ElasticsearchTestCase {
                     try {
                         GoogleCloudStorageService service = new MockGoogleCloudStorageService(ImmutableSettings.EMPTY, result);
                         GoogleCloudStorageConcurrentUpload upload = new GoogleCloudStorageConcurrentUpload(service, "test-bucket", "test-blob-" + num);
-                        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload);
+                        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload, bufferSize);
 
                         for (int i = 0; i < randomLength; i++) {
                             content.write(randomByte());

--- a/src/test/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStreamTest.java
+++ b/src/test/java/org/elasticsearch/cloud/gce/blobstore/GoogleCloudStorageOutputStreamTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.repositories.gce.MockGoogleCloudStorageService;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.common.io.Streams.copy;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Unit test for {@link GoogleCloudStorageOutputStream}.
+ */
+public class GoogleCloudStorageOutputStreamTest extends ElasticsearchTestCase {
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUpExecutor() {
+        executor = Executors.newFixedThreadPool(1);
+    }
+
+    @After
+    public void tearDownExecutor() throws InterruptedException {
+        if (executor != null) {
+            executor.shutdown();
+            boolean done = executor.awaitTermination(10, TimeUnit.SECONDS);
+            if (!done) {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    public void testWriteRandomDataToMockConcurrentUpload() throws IOException {
+        ConcurrentUpload<byte[]> upload = new MockConcurrentUpload();
+        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload);
+
+        Integer randomLength = randomIntBetween(1, 10000000);
+        ByteArrayOutputStream content = new ByteArrayOutputStream(randomLength);
+        for (int i = 0; i < randomLength; i++) {
+            content.write(randomByte());
+        }
+
+        copy(content.toByteArray(), out);
+
+        // Checks length & content
+        assertThat(upload.getUploadedObject().length, equalTo(randomLength));
+        assertThat(Arrays.equals(upload.getUploadedObject(), content.toByteArray()), equalTo(true));
+        assertTrue(upload.isCompleted());
+    }
+
+    @Test
+    public void testWriteRandomDataToGoogleCloudStorageConcurrentUpload() throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+
+        GoogleCloudStorageService service = new MockGoogleCloudStorageService(ImmutableSettings.EMPTY, result);
+
+        GoogleCloudStorageConcurrentUpload upload = new GoogleCloudStorageConcurrentUpload(service, "test-bucket", "test-project");
+        GoogleCloudStorageOutputStream out = new GoogleCloudStorageOutputStream(executor, upload);
+
+        Integer randomLength = randomIntBetween(1, 10000000);
+        ByteArrayOutputStream content = new ByteArrayOutputStream(randomLength);
+        for (int i = 0; i < randomLength; i++) {
+            content.write(randomByte());
+        }
+
+        copy(content.toByteArray(), out);
+
+        // Checks length & content
+        assertThat(upload.getUploadedObject().getSize().intValue(), equalTo(randomLength));
+        assertThat(Arrays.equals(result.toByteArray(), content.toByteArray()), equalTo(true));
+    }
+}

--- a/src/test/java/org/elasticsearch/cloud/gce/blobstore/MockConcurrentUpload.java
+++ b/src/test/java/org/elasticsearch/cloud/gce/blobstore/MockConcurrentUpload.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce.blobstore;
+
+import org.elasticsearch.common.io.Streams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class MockConcurrentUpload implements ConcurrentUpload<byte[]> {
+
+    private InputStream in = null;
+    private ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    private boolean completed = false;
+    private Exception exception;
+
+    private final CountDownLatch done = new CountDownLatch(1);
+
+    @Override
+    public void initializeUpload(InputStream inputStream) throws IOException {
+        this.in = inputStream;
+    }
+
+    @Override
+    public void waitForCompletion() {
+        while ((done.getCount() > 0) && (exception == null)) {
+            try {
+                completed = done.await(50, TimeUnit.MILLISECONDS);
+                if (completed) {
+                    return;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    @Override
+    public byte[] getUploadedObject() {
+        return out.toByteArray();
+    }
+
+    @Override
+    public Exception getException() {
+        return exception;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Streams.copy(in, out);
+            completed = true;
+        } catch (IOException e) {
+            exception = e;
+        } finally {
+            done.countDown();
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/repositories/gce/AbstractGoogleCloudStorageRepositoryServiceTest.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/AbstractGoogleCloudStorageRepositoryServiceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+import org.elasticsearch.cloud.gce.AbstractGceTest;
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.repositories.RepositoryMissingException;
+import org.elasticsearch.test.store.MockDirectoryHelper;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public abstract class AbstractGoogleCloudStorageRepositoryServiceTest extends AbstractGceTest {
+
+    protected String basePath;
+
+    @Before
+    public final void wipeBefore() {
+        wipeRepositories();
+        basePath = "repo-" + randomInt();
+        cleanRepositoryFiles(basePath);
+    }
+
+    @After
+    public final void wipeAfter() {
+        wipeRepositories();
+        cleanRepositoryFiles(basePath);
+    }
+
+
+    @Override
+    public Settings indexSettings() {
+        // During restore we frequently restore index to exactly the same state it was before, that might cause the same
+        // checksum file to be written twice during restore operation
+        return ImmutableSettings.builder().put(super.indexSettings())
+                .put(MockDirectoryHelper.RANDOM_PREVENT_DOUBLE_WRITE, false)
+                .put(MockDirectoryHelper.RANDOM_NO_DELETE_OPEN_FILE, false)
+                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
+                .build();
+    }
+
+    /**
+     * Deletes repositories, supports wildcard notation.
+     */
+    public static void wipeRepositories(String... repositories) {
+        // if nothing is provided, delete all
+        if (repositories.length == 0) {
+            repositories = new String[]{"*"};
+        }
+        for (String repository : repositories) {
+            try {
+                client().admin().cluster().prepareDeleteRepository(repository).execute().actionGet();
+            } catch (RepositoryMissingException ex) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * Deletes content of the repository files in the bucket
+     */
+    public void cleanRepositoryFiles(String path) {
+        String defaultBucket = internalCluster().getInstance(Settings.class).get("repositories.gcs.bucket");
+        logger.info("--> remove blobs in bucket [{}]", defaultBucket);
+        GoogleCloudStorageService client = internalCluster().getInstance(GoogleCloudStorageService.class);
+        try {
+            client.deleteBlobs(defaultBucket, path);
+        } catch (IOException e) {
+            logger.error("exception when deleting blobs in test", e);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreITest.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreITest.java
@@ -67,6 +67,7 @@ public class GoogleCloudStorageSnapshotRestoreITest extends AbstractGoogleCloudS
                 .setType(GoogleCloudStorageRepository.TYPE)
                 .setSettings(ImmutableSettings.settingsBuilder()
                                 .put("base_path", basePath)
+                                .put("concurrent_streams", randomIntBetween(1, 5))
                                 .put("chunk_size", randomIntBetween(1000, 10000))
                 ).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));

--- a/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreITest.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreITest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cloud.gce.AbstractGceTest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.snapshots.SnapshotMissingException;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.store.MockDirectoryHelper;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * This test needs a Google Cloud Storage account to run and -Dtests.gce=true to be set and -Dtests.gce=/path/to/elasticsearch.yml
+ *
+ * @see org.elasticsearch.cloud.gce.AbstractGceTest
+ */
+@AbstractGceTest.GceTest
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 2, numClientNodes = 0, transportClientRatio = 0.0)
+public class GoogleCloudStorageSnapshotRestoreITest extends AbstractGoogleCloudStorageRepositoryServiceTest {
+
+    @Override
+    public Settings indexSettings() {
+        // During restore we frequently restore index to exactly the same state it was before, that might cause the same
+        // checksum file to be written twice during restore operation
+        return ImmutableSettings.builder().put(super.indexSettings())
+                .put(MockDirectoryHelper.RANDOM_PREVENT_DOUBLE_WRITE, false)
+                .put(MockDirectoryHelper.RANDOM_NO_DELETE_OPEN_FILE, false)
+                .put("cloud.enabled", true)
+                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
+                .build();
+    }
+
+    @Test
+    public void testSimpleWorkflow() {
+        Client client = client();
+        logger.info("-->  creating GCS repository with bucket[{}] and path [{}]", internalCluster().getInstance(Settings.class).get("repositories.gcs.bucket"), basePath);
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType(GoogleCloudStorageRepository.TYPE)
+                .setSettings(ImmutableSettings.settingsBuilder()
+                                .put("base_path", basePath)
+                                .put("chunk_size", randomIntBetween(1000, 10000))
+                ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        ensureGreen();
+
+        logger.info("--> indexing some data");
+        for (int i = 0; i < 100; i++) {
+            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+        refresh();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(100L));
+
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-3").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        assertThat(client.admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+
+        logger.info("--> delete some data");
+        for (int i = 0; i < 50; i++) {
+            client.prepareDelete("test-idx-1", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 50; i < 100; i++) {
+            client.prepareDelete("test-idx-2", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 0; i < 100; i += 2) {
+            client.prepareDelete("test-idx-3", "doc", Integer.toString(i)).get();
+        }
+        refresh();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(50L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(50L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(50L));
+
+        logger.info("--> close indices");
+        client.admin().indices().prepareClose("test-idx-1", "test-idx-2").get();
+
+        logger.info("--> restore all indices from the snapshot");
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+
+        ensureGreen();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(50L));
+
+        // Test restore after index deletion
+        logger.info("--> delete indices");
+        cluster().wipeIndices("test-idx-1", "test-idx-2");
+        logger.info("--> restore one index after deletion");
+        restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-2").execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+        ensureGreen();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-1"), equalTo(true));
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-2"), equalTo(false));
+    }
+
+
+    @Test
+    public void testRestoringNonExistingRepository() {
+
+        Client client = client();
+        logger.info("-->  creating GCS repository with bucket[{}] and path [{}]", internalCluster().getInstance(Settings.class).get("repositories.gcs.bucket"), basePath);
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType(GoogleCloudStorageRepository.TYPE)
+                .setSettings(ImmutableSettings.settingsBuilder()
+                                .put("base_path", basePath)
+                ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+
+        logger.info("--> restore non existing snapshot");
+        try {
+            client.admin().cluster().prepareRestoreSnapshot("test-repo", "no-existing-snapshot").setWaitForCompletion(true).execute().actionGet();
+            fail("Shouldn't be here");
+        } catch (SnapshotMissingException ex) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testGetAndDeleteNonExistingSnapshot() {
+        Client client = client();
+        logger.info("-->  creating GCS repository without any path");
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType(GoogleCloudStorageRepository.TYPE)
+                .setSettings(ImmutableSettings.settingsBuilder()
+                                .put("base_path", basePath)
+                ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+
+        try {
+            client.admin().cluster().prepareGetSnapshots("test-repo").addSnapshots("no-existing-snapshot").get();
+            fail("Shouldn't be here");
+        } catch (SnapshotMissingException ex) {
+            // Expected
+        }
+
+        try {
+            client.admin().cluster().prepareDeleteSnapshot("test-repo", "no-existing-snapshot").get();
+            fail("Shouldn't be here");
+        } catch (SnapshotMissingException ex) {
+            // Expected
+        }
+    }
+
+}

--- a/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreTest.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/GoogleCloudStorageSnapshotRestoreTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ElasticsearchIntegrationTest.ClusterScope(
+        scope = ElasticsearchIntegrationTest.Scope.SUITE,
+        numDataNodes = 1,
+        numClientNodes = 0,
+        transportClientRatio = 0.0)
+public class GoogleCloudStorageSnapshotRestoreTest extends AbstractGoogleCloudStorageRepositoryServiceTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
+                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
+                .put("cloud.enabled", true)
+                .put("repositories.gcs.credentials_file", "none :)")
+                .put("repositories.gcs.project_id", "default-project")
+                .put("repositories.gcs.bucket", "default-bucket")
+                .put("cloud.gce.storage.api.impl", MockGoogleCloudStorageService.class);
+        return builder.build();
+    }
+
+    @Test
+    public void testSimpleWorkflow() {
+        Client client = client();
+        logger.info("-->  creating GCS repository with bucket[{}] and path [{}]", internalCluster().getInstance(Settings.class).get("repositories.gcs.bucket"), basePath);
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType(GoogleCloudStorageRepository.TYPE)
+                .setSettings(ImmutableSettings.settingsBuilder()
+                                .put("base_path", basePath)
+                                .put("chunk_size", randomIntBetween(1000, 10000))
+                ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+
+        createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        ensureGreen();
+
+        logger.info("--> indexing some data");
+        for (int i = 0; i < 100; i++) {
+            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+        refresh();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(100L));
+
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-3").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        assertThat(client.admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+
+        logger.info("--> delete some data");
+        for (int i = 0; i < 50; i++) {
+            client.prepareDelete("test-idx-1", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 50; i < 100; i++) {
+            client.prepareDelete("test-idx-2", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 0; i < 100; i += 2) {
+            client.prepareDelete("test-idx-3", "doc", Integer.toString(i)).get();
+        }
+        refresh();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(50L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(50L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(50L));
+
+        logger.info("--> close indices");
+        client.admin().indices().prepareClose("test-idx-1", "test-idx-2").get();
+
+        logger.info("--> restore all indices from the snapshot");
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+
+        ensureGreen();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-2").get().getCount(), equalTo(100L));
+        assertThat(client.prepareCount("test-idx-3").get().getCount(), equalTo(50L));
+
+        // Test restore after index deletion
+        logger.info("--> delete indices");
+        cluster().wipeIndices("test-idx-1", "test-idx-2");
+        logger.info("--> restore one index after deletion");
+        restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-2").execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+        ensureGreen();
+        assertThat(client.prepareCount("test-idx-1").get().getCount(), equalTo(100L));
+        ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-1"), equalTo(true));
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-2"), equalTo(false));
+    }
+
+}

--- a/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cloud.gce.GoogleCloudStorageService;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.*;
+import java.nio.file.FileAlreadyExistsException;
+import java.security.GeneralSecurityException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * In memory storage for unit tests
+ */
+public class MockGoogleCloudStorageService extends AbstractLifecycleComponent<GoogleCloudStorageService>
+        implements GoogleCloudStorageService {
+
+    protected Map<String, Set<String>> buckets = new ConcurrentHashMap<>();
+    protected Map<String, ByteArrayOutputStream> blobs = new ConcurrentHashMap<>();
+
+    /**
+     * This is the OutputStream in which the request implemented in MockStorage.MockObjects.MockInsert
+     */
+    private ByteArrayOutputStream requestOutputStream;
+
+    @Inject
+    public MockGoogleCloudStorageService(Settings settings, ByteArrayOutputStream requestOutputStream) {
+        super(settings);
+        this.requestOutputStream = requestOutputStream;
+    }
+
+    private String key(String bucketName, String blob) {
+        return String.format("#%s#%s", bucketName, blob);
+    }
+
+    private String reverseKey(String path) {
+        if (path.contains("#")) {
+            return path.substring(path.lastIndexOf('#') + 1);
+        }
+        return path;
+    }
+
+    @Override
+    protected void doStart() throws ElasticsearchException {
+
+    }
+
+    @Override
+    protected void doStop() throws ElasticsearchException {
+
+    }
+
+    @Override
+    protected void doClose() throws ElasticsearchException {
+
+    }
+
+    @Override
+    public boolean doesBucketExist(String bucketName) throws IOException {
+        for (Set<String> b : buckets.values()) {
+            if (b.contains(bucketName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void createBucket(String projectName, String bucketName, String location) throws IOException {
+        Set<String> projectBuckets = buckets.get(projectName);
+        if (projectBuckets == null) {
+            projectBuckets = new CopyOnWriteArraySet<>();
+            projectBuckets.add(bucketName);
+            buckets.put(projectName, projectBuckets);
+        } else {
+            if (projectBuckets.contains(bucketName)) {
+                throw new FileAlreadyExistsException("Mock service indicates that bucket already exists");
+            }
+        }
+    }
+
+    @Override
+    public void deleteBlobs(String bucketName, String path) throws IOException {
+        Set<String> markAsDeleted = new HashSet<>();
+
+        for (String blobName : blobs.keySet()) {
+            if (blobName.startsWith(path)) {
+                markAsDeleted.add(blobName);
+            }
+        }
+        if (!markAsDeleted.isEmpty()) {
+            for (String delete : markAsDeleted) {
+                blobs.remove(delete);
+            }
+        }
+    }
+
+    @Override
+    public boolean blobExists(String bucketName, String blobName) throws IOException {
+        return blobs.containsKey(key(bucketName, blobName));
+    }
+
+    @Override
+    public void deleteBlob(String bucketName, String blobName) throws IOException {
+        if (!blobs.containsKey(key(bucketName, blobName))) {
+            throw new FileNotFoundException("Mock service indicates that bucket does not exists");
+        }
+
+    }
+
+    @Override
+    public InputStream getInputStream(String bucketName, String blobName) throws IOException {
+        if (!blobs.containsKey(key(bucketName, blobName))) {
+            throw new FileNotFoundException("Mock service indicates that blob does not exists");
+        }
+        return new ByteArrayInputStream(blobs.get(key(bucketName, blobName)).toByteArray());
+    }
+
+    @Override
+    public OutputStream getOutputStream(String bucketName, String blobName) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        blobs.put(key(bucketName, blobName), outputStream);
+        return outputStream;
+    }
+
+    @Override
+    public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(String bucketName, String path, String prefix) throws IOException {
+        ImmutableMap.Builder<String, BlobMetaData> blobsBuilder = ImmutableMap.builder();
+        for (String blobKey : blobs.keySet()) {
+            String blobName = reverseKey(blobKey);
+            if (blobName.startsWith(path + (prefix != null ? prefix : ""))) {
+                blobsBuilder.put(blobName, new PlainBlobMetaData(blobName, blobs.get(blobKey).size()));
+            }
+        }
+        return blobsBuilder.build();
+    }
+
+    @Override
+    public Storage.Objects.Insert prepareInsert(String bucketName, String blobName, InputStream input) throws IOException {
+        try {
+            InputStreamContent streamContent =  new InputStreamContent("application/octet-stream", input);
+            return new MockStorage(requestOutputStream).objects().insert(bucketName, new StorageObject().setName(blobName), streamContent);
+        } catch (GeneralSecurityException gse) {
+            // We are mocking a class, we don't really care about this exception.
+            throw new IOException(gse);
+        }
+    }
+}

--- a/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
@@ -149,7 +149,7 @@ public class MockGoogleCloudStorageService extends AbstractLifecycleComponent<Go
     }
 
     @Override
-    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException {
+    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName, int bufferSize) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         blobs.put(key(bucketName, blobName), outputStream);
         return outputStream;

--- a/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/MockGoogleCloudStorageService.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executor;
 
 /**
  * In memory storage for unit tests
@@ -148,7 +149,7 @@ public class MockGoogleCloudStorageService extends AbstractLifecycleComponent<Go
     }
 
     @Override
-    public OutputStream getOutputStream(String bucketName, String blobName) throws IOException {
+    public OutputStream getOutputStream(Executor executor, String bucketName, String blobName) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         blobs.put(key(bucketName, blobName), outputStream);
         return outputStream;

--- a/src/test/java/org/elasticsearch/repositories/gce/MockStorage.java
+++ b/src/test/java/org/elasticsearch/repositories/gce/MockStorage.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.gce;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.AbstractInputStreamContent;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import org.elasticsearch.common.io.Streams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.util.concurrent.TimeUnit;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomInt;
+
+public class MockStorage extends Storage {
+
+    private final ByteArrayOutputStream requestOutputStream;
+
+    public MockStorage(ByteArrayOutputStream requestOutputStream) throws GeneralSecurityException, IOException {
+        super(GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory.getDefaultInstance(), null);
+        this.requestOutputStream = requestOutputStream;
+    }
+
+    public byte[] getRequestOutputStreamAsByteArray() {
+        return requestOutputStream.toByteArray();
+    }
+
+    @Override
+    public Objects objects() {
+        return new MockObjects();
+    }
+
+    public class MockObjects extends Storage.Objects {
+
+        @Override
+        public Insert insert(String bucket, StorageObject content, AbstractInputStreamContent mediaContent) throws IOException {
+            return new MockInsert(bucket, content, mediaContent);
+        }
+
+        public class MockInsert extends Storage.Objects.Insert {
+
+            AbstractInputStreamContent content;
+
+            protected MockInsert(String bucket, StorageObject content, AbstractInputStreamContent mediaContent) {
+                super(bucket, content, mediaContent);
+                this.content = mediaContent;
+            }
+
+            @Override
+            public StorageObject execute() throws IOException {
+                StorageObject result = new StorageObject();
+
+                try {
+                    long copied = Streams.copy(content.getInputStream(), requestOutputStream);
+                    result.setSize(BigInteger.valueOf(copied));
+
+                    TimeUnit.SECONDS.sleep(randomInt(10));
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Snapshot/Restore API: Add Google Cloud Storage support

Adds the ability to snapshot/restore indices to/from the Google Cloud Storage platform. This functionnality also works when the plugin is installed on a Compute Engine instance. The authorization process is based on "service account" files, which is the recommanded way to auhenticate application against the GCS service. This implementation uses the Google Storage API (v0.19.0), and the uploading of blobs are executed in a background thread.

Closes #11
